### PR TITLE
Oppdater environmentvariabler satt av mutatingflow

### DIFF
--- a/pkg/commons/utils.go
+++ b/pkg/commons/utils.go
@@ -21,9 +21,9 @@ var (
 	}
 	dataverkEnvs = map[string]string{
 		"DATAVERK_SECRETS_FROM_FILES": "True",
-		"DATAVERK_BUCKET_ENDPOINT":    "https://dataverk-s3-api.nais.adeo.no",
 		"REQUESTS_CA_BUNDLE":          "/etc/pki/tls/certs/ca-bundle.crt",
 		"SSL_CERT_FILE":               "/etc/pki/tls/certs/ca-bundle.crt",
+		"VKS_SECRET_DEST_PATH":        "/var/run/secrets/nais.io/vault",
 	}
 	proxyEnvs = map[string]string{
 		"NO_PROXY":    "localhost,127.0.0.1,10.254.0.1,.local,.adeo.no,.nav.no,.aetat.no,.devillo.no,.oera.no,.nais.io",


### PR DESCRIPTION
- Fjernet DATAVERK_BUCKET_ENDPOINT. Verdien av denne vil variere i ulike miljø og kan ikke settes av mutatingflow
- La til VKS_SECRET_DEST_PATH. Usikker på om denne passer inn under "dataverkEnvs"